### PR TITLE
[FIX] account_invoice_triple_discount: restore original discount field's precision by using change_digit function

### DIFF
--- a/account_invoice_triple_discount/models/line_triple_discount.py
+++ b/account_invoice_triple_discount/models/line_triple_discount.py
@@ -84,7 +84,6 @@ class LineTripleDiscount (models.AbstractModel):
         # more digits than allowed from field's precision,
         # so let's increase it just for saving it correctly in cache
         discount_field = self._fields['discount']
-        discount_original_digits = discount_field._digits
         discount_field._digits = (16, 10)
 
         for line in self:
@@ -100,7 +99,7 @@ class LineTripleDiscount (models.AbstractModel):
             })
 
         # Restore discount field's precision
-        discount_field._digits = discount_original_digits
+        discount_field._digits = dp.get_precision("Discount")(self.env.cr)
         return prev_values
 
     @api.model


### PR DESCRIPTION
Use change_digit function to restore original discount field's precision in order to avoid to have always (16, 10) as precision in case of any errors.